### PR TITLE
chore: move cloudflare DNS from k8s to compute

### DIFF
--- a/Pulumi.public.yaml
+++ b/Pulumi.public.yaml
@@ -4,6 +4,7 @@ config:
   o-p-n:domain: outer-planes.net
   o-p-n:cloudflare:
     account: 09e23dd041054ac8d267a7e115f96d29
+    zone: c5660ae123056b05b14d7b21e360fcf8
   o-p-n:disabled:
     metallb: true
   cloudflare:apiToken:

--- a/modules/cloudflare/index.ts
+++ b/modules/cloudflare/index.ts
@@ -13,10 +13,9 @@ const config = new Config("o-p-n");
 
 export default async function stack(provider: k8s.Provider, deployed: ModuleResultSet) {
   const settings = config.requireObject<Settings>("cloudflare");
-  const accountId = settings.account;
+  const { account: accountId, zone: zoneId } = settings;
 
-  const dns = dnsStack(accountId);
-  const tunnel = tunnelStack(accountId, dns.zone);
+  const tunnel = tunnelStack(accountId, zoneId);
   const k8s = k8sStack(tunnel.token, provider, deployed);
 
   return k8s;

--- a/modules/cloudflare/tunnel.ts
+++ b/modules/cloudflare/tunnel.ts
@@ -3,8 +3,7 @@ import { getStack, Config } from "@pulumi/pulumi";
 
 const config = new Config("o-p-n");
 
-export default function tunnelStack(accountId: string, zone: cf.Zone) {
-  const zoneId = zone.id;
+export default function tunnelStack(accountId: string, zoneId: string) {
   const domain = config.require("domain");
   const stack = getStack();
   

--- a/modules/cloudflare/types.ts
+++ b/modules/cloudflare/types.ts
@@ -1,4 +1,5 @@
 export interface Settings {
   account: string;
+  zone: string;
   caPool?: string;
 }

--- a/projects/o-p-n.compute/index.ts
+++ b/projects/o-p-n.compute/index.ts
@@ -10,6 +10,7 @@ import deployKind from "./kind";
 import deployMicrok8s from "./microk8s";
 import doStack from "../../modules/digitalocean";
 import { OrgSecret } from "../../modules/github/secrets";
+import cfDnsStack from "../../modules/cloudflare/dns";
 
 const config = new Config("o-p-n");
 
@@ -35,6 +36,9 @@ export = async () => {
   }
 
   const outputs = await deployer(domain, resOpts);
+  if (enabled.cloudflare) {
+    cfDnsStack(domain);
+  }
 
   if (enabled.github) {
     const secret = new OrgSecret("kubeconfig-secret", {


### PR DESCRIPTION
This gets around a frequent problem of restarting the `k8s` stack and losing all the DNS record state.